### PR TITLE
Remove double sinatra helpers call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tmp
 .yardoc
 _yardoc
 doc/
+/vendor/bundle

--- a/lib/helios/backend/data.rb
+++ b/lib/helios/backend/data.rb
@@ -14,8 +14,6 @@ class Helios::Backend::Data < Sinatra::Base
     content_type :json
   end
 
-  helpers Sinatra::Param
-
   options '/' do
     pass unless self.class < Helios::Administerable
 


### PR DESCRIPTION
Was reading through the code and noticed that `helpers Sinatra::Param` was called twice in lib/helios/backend/data.rb
