### PR TITLE
Push Notification posting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Bundler.require
 
 run Helios::Application.new do
   service :data, model: 'path/to/DataModel.xcdatamodel'
-  service :push_notification
+  service :push_notification, apn_certificate: 'path/to/apple_push_notification.pem', apn_environment: 'development'
   service :in_app_purchase
   service :passbook
 end
@@ -111,7 +111,7 @@ Helios can be run as Rails middleware by adding this to the configuration block 
 ```ruby
 config.middleware.use Helios::Application do
   service :data, model: 'path/to/DataModel.xcdatamodel'
-  service :push_notification
+  service :push_notification, apn_certificate: 'path/to/apple_push_notification.pem', apn_environment: 'development'
   service :in_app_purchase
   service :passbook
 end
@@ -172,6 +172,10 @@ Each entity in the specified data model will have a `Sequel::Model` subclass cre
   <tr>
     <td><tt>DELETE /devices/:token</tt></td>
     <td>Unregister a device from receiving push notifications</td>
+  </tr>
+  <tr>
+    <td><tt>POST /message</tt></td>
+    <td>Send out a push notification to some devices</td>
   </tr>
 </table>
 
@@ -275,6 +279,12 @@ To run Helios in development mode on `localhost`, run the `server` command:
 
     $ helios server
 
+### Testing Push Notifications
+
+Once you have registered a device and set up your certificate, try this:
+
+    $ curl -X POST -d 'payload={"aps": {"alert":"Blastoff!"}}' http://localhost:5000/message
+
 ### Running the Helios Console
 
 You can start an IRB session with the runtime environment of the Helios application with the `console` command:
@@ -319,6 +329,21 @@ didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
     }];
 }
 ```
+
+### Converting Your Push Notification Certificate
+
+> These instructions come from the [APN on Rails](https://github.com/PRX/apn_on_rails) project.
+
+Once you have the certificate from Apple for your application, export your key
+and the apple certificate as p12 files. Here is a quick walkthrough on how to do this:
+
+1. Click the disclosure arrow next to your certificate in Keychain Access and select the certificate and the key. 
+2. Right click and choose `Export 2 items…`. 
+3. Choose the p12 format from the drop down and name it `cert.p12`.
+
+Now covert the p12 file to a pem file:
+
+    $ openssl pkcs12 -in cert.p12 -out apple_push_notification.pem -nodes -clcerts
 
 ## Coming Attractions
 

--- a/lib/helios/backend/push-notification.rb
+++ b/lib/helios/backend/push-notification.rb
@@ -4,19 +4,12 @@ require 'houston'
 
 class Helios::Backend::PushNotification < Sinatra::Base
   helpers Sinatra::Param  
+  attr_reader :apn_certificate, :apn_environment
 
   def initialize(app, options = {})
     super(Rack::PushNotification.new)
-    @apn_certificate = options[:apn_certificate]
-    @apn_environment = options[:apn_environment]
-  end
-
-  def apn_certificate
-    @apn_certificate || ENV['APN_CERTIFICATE']
-  end
-
-  def apn_environment
-    @apn_environment || ENV['APN_ENVIRONMENT']
+    @apn_certificate = options[:apn_certificate] || ENV['APN_CERTIFICATE']
+    @apn_environment = options[:apn_environment] || ENV['APN_ENVIRONMENT']
   end
 
   get '/devices/?' do

--- a/lib/helios/backend/push-notification.rb
+++ b/lib/helios/backend/push-notification.rb
@@ -1,11 +1,22 @@
 require 'rack/push-notification'
 require 'sinatra/param'
+require 'houston'
 
 class Helios::Backend::PushNotification < Sinatra::Base
   helpers Sinatra::Param  
 
   def initialize(app, options = {})
     super(Rack::PushNotification.new)
+    @apn_certificate = options[:apn_certificate]
+    @apn_environment = options[:apn_environment]
+  end
+
+  def apn_certificate
+    @apn_certificate || ENV['APN_CERTIFICATE']
+  end
+
+  def apn_environment
+    @apn_environment || ENV['APN_ENVIRONMENT']
   end
 
   get '/devices/?' do
@@ -79,16 +90,16 @@ class Helios::Backend::PushNotification < Sinatra::Base
 
   def client
     begin
-      return nil unless settings.apn_certificate and ::File.exist?(settings.apn_certificate)
+      return nil unless apn_certificate and ::File.exist?(apn_certificate)
       
-      client = case settings.apn_environment.to_sym
+      client = case apn_environment.to_sym
                 when :development 
                   Houston::Client.development
                 when :production
                   Houston::Client.production
                 end
-      client.certificate = ::File.read(settings.apn_certificate)
-      
+      client.certificate = ::File.read(apn_certificate)
+
       return client
     rescue
       return nil


### PR DESCRIPTION
Additions:
- `apn_certificate` and `apn_environment` can be passed in `config.ru` or added as `ENV` variables
- fixes POST `/message`
- some help in `README.md`
