### PR TITLE
Fix helios console command to work with Foreman ~> 0.63

### DIFF
--- a/example/.env
+++ b/example/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://localhost/helios

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
-  remote: /Users/mattt/Code/Ruby/helios
+  remote: /Users/bart/Projects/helios
   specs:
     helios (0.2.0)
       coffee-script (~> 2.2)
       commander (~> 4.1)
       compass (~> 0.12)
-      foreman (~> 0.60)
-      haml (~> 3.1)
+      foreman (~> 0.63)
+      haml (>= 3.1)
       json (~> 1.7)
       rack-contrib (~> 1.1)
       rack-core-data (~> 0.3)
@@ -28,7 +28,7 @@ GEM
     activesupport (3.2.13)
       i18n (= 0.6.1)
       multi_json (~> 1.0)
-    backports (3.1.1)
+    backports (3.3.0)
     chunky_png (1.2.8)
     coffee-script (2.2.0)
       coffee-script-source
@@ -40,18 +40,21 @@ GEM
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
+    dotenv (0.7.0)
     eventmachine (1.0.3)
     excon (0.17.0)
     execjs (1.4.0)
       multi_json (~> 1.0)
     faraday (0.8.6)
       multipart-post (~> 1.1)
-    foreman (0.62.0)
+    foreman (0.63.0)
+      dotenv (>= 0.7)
       thor (>= 0.13.6)
     fssm (0.2.10)
-    haml (3.1.8)
+    haml (4.0.2)
+      tilt
     hashie (1.2.0)
-    highline (1.6.16)
+    highline (1.6.18)
     houston (0.1.1)
       commander (~> 4.1.2)
       json (~> 1.7.3)
@@ -115,24 +118,24 @@ GEM
     rails-database-url (1.0.0)
     raindrops (0.10.0)
     sass (3.2.7)
-    sequel (3.45.0)
-    sinatra (1.3.6)
-      rack (~> 1.4)
-      rack-protection (~> 1.3)
-      tilt (~> 1.3, >= 1.3.3)
+    sequel (3.46.0)
+    sinatra (1.4.2)
+      rack (~> 1.5, >= 1.5.2)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
     sinatra-assetpack (0.1.7)
       jsmin
       rack-test
       sinatra
       tilt (>= 1.3.0)
-    sinatra-backbone (0.1.0.rc2)
+    sinatra-backbone (0.1.1)
       sinatra
-    sinatra-contrib (1.3.2)
+    sinatra-contrib (1.4.0)
       backports (>= 2.0)
       eventmachine
       rack-protection
       rack-test
-      sinatra (~> 1.3.0)
+      sinatra (~> 1.4.2)
       tilt (~> 1.3)
     sinatra-param (0.1.2)
       sinatra (~> 1.3)
@@ -140,7 +143,7 @@ GEM
       sinatra (>= 1.0)
     terminal-table (1.4.5)
     thor (0.18.1)
-    tilt (1.3.6)
+    tilt (1.3.7)
     unicorn (4.6.2)
       kgio (~> 2.6)
       rack
@@ -150,7 +153,7 @@ GEM
       excon (~> 0.17.0)
       json (~> 1.7.3)
       terminal-table (~> 1.4.5)
-    zurb-foundation (4.0.9)
+    zurb-foundation (4.1.2)
       sass (>= 3.2.0)
 
 PLATFORMS

--- a/helios.gemspec
+++ b/helios.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "Helios is an open-source framework that provides essential backend services for iOS apps, from data synchronization and user accounts to push notifications, in-app purchases, and passbook integration. It allows developers to get a client-server app up-and-running in just a few minutes, and seamlessly incorporate functionality as necessary."
 
   s.add_dependency "commander", "~> 4.1"
-  s.add_dependency "foreman", "~> 0.60"
+  s.add_dependency "foreman", "~> 0.63"
   s.add_dependency "rack-contrib", "~> 1.1"
   s.add_dependency "rack-core-data", "~> 0.3"
   s.add_dependency "rack-push-notification", "~> 0.4"

--- a/lib/helios/commands/console.rb
+++ b/lib/helios/commands/console.rb
@@ -4,13 +4,11 @@ command :console do |c|
 
   c.action do |args, options|
       require 'irb'
-      require 'foreman/env'
+      require 'dotenv'
       require 'sequel'
 
       @env = {}
-      Foreman::Env.new(".env").entries do |name, value|
-        @env[name] = value
-      end
+      @env.update Dotenv::Environment.new(".env")
 
       Sequel.connect(@env['DATABASE_URL'])
 


### PR DESCRIPTION
Starting from 0.63, foreman has switched to Dotenv instead of
foreman-env.

This patch upgrades the foreman dependency to ~> 0.63, and fixes the
`helios console` command by merging the @env hash with values from
Dotenv::Environment.
