### PR TITLE
Ignore the .sass-cache folder created by the example project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+example/.sass-cache
 
 # YARD artifacts
 .yardoc


### PR DESCRIPTION
Tiny update to the .gitignore file, and reduces a _lot_ of clutter from `git status`
