### PR TITLE
Add warning about using link

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ In order to keep your data model and REST webservices in sync, you can link it t
 
 This creates a hard link between the data model file in your Xcode and Helios projects—any changes made to either file will affect both. The next time you start the server, Helios will automatically migrate the database to create tables and insert columns to accomodate any new entities or attributes.
 
+**Please Note**: If you are using OS X you should not attempt to delete your Helios application directory using `rm -r` if you have linked a Core Data model. Doing so will result in the removal of the Xcode data model. Instead use the finder to move the Helios application directory to trash.
+
 ### Starting the Application Locally
 
 To run Helios in development mode on `localhost`, run the `server` command:


### PR DESCRIPTION
I don't know if this is the best wording but it seems like there needs to be some type of warning about how to remove the directory after creating a link. If you use `rm -r` on the parent you will end up deleting your original Xcode model as well. I'm actually surprised that using the trash works but it must look at the attributes of the directory before descending into it.
