### PR TITLE
Fix JS and CSS asset paths

### DIFF
--- a/lib/helios/frontend.rb
+++ b/lib/helios/frontend.rb
@@ -25,31 +25,31 @@ module Helios
       serve '/fonts', from: '/fonts'
 
       js :application, '/javascripts/application.js', [
-        'javascripts/vendor/jquery.js',
-        'javascripts/vendor/jquery/jquery.ui.widget.js',
-        'javascripts/vendor/jquery/jquery.fileupload.js',
-        'javascripts/vendor/jquery/jquery.fileupload-ui.js',
-        'javascripts/vendor/underscore.js',
-        'javascripts/vendor/backbone.js',
-        'javascripts/vendor/backbone.paginator.js',
-        'javascripts/vendor/backbone.datagrid.js',
-        'javascripts/vendor/codemirror.js',
-        'javascripts/vendor/codemirror.javascript.js',
-        'javascripts/vendor/foundation.js',
-        'javascripts/vendor/foundation/foundation.dropdown.js',
-        'javascripts/vendor/foundation/foundation.reveal.js',
-        'javascripts/vendor/date.js',
-        'javascripts/vendor/linkheaders.js',
-        'javascripts/helios.js',
-        'javascripts/helios/models.js',
-        'javascripts/helios/collections.js',
-        'javascripts/helios/templates.js',
-        'javascripts/helios/views.js',
-        'javascripts/helios/router.js',
+        '/javascripts/vendor/jquery.js',
+        '/javascripts/vendor/jquery/jquery.ui.widget.js',
+        '/javascripts/vendor/jquery/jquery.fileupload.js',
+        '/javascripts/vendor/jquery/jquery.fileupload-ui.js',
+        '/javascripts/vendor/underscore.js',
+        '/javascripts/vendor/backbone.js',
+        '/javascripts/vendor/backbone.paginator.js',
+        '/javascripts/vendor/backbone.datagrid.js',
+        '/javascripts/vendor/codemirror.js',
+        '/javascripts/vendor/codemirror.javascript.js',
+        '/javascripts/vendor/foundation.js',
+        '/javascripts/vendor/foundation/foundation.dropdown.js',
+        '/javascripts/vendor/foundation/foundation.reveal.js',
+        '/javascripts/vendor/date.js',
+        '/javascripts/vendor/linkheaders.js',
+        '/javascripts/helios.js',
+        '/javascripts/helios/models.js',
+        '/javascripts/helios/collections.js',
+        '/javascripts/helios/templates.js',
+        '/javascripts/helios/views.js',
+        '/javascripts/helios/router.js',
       ]
 
       css :application, '/stylesheets/application.css', [
-        'stylesheets/screen.css'
+        '/stylesheets/screen.css'
       ]
     end
 


### PR DESCRIPTION
Fixes #64.

Assets were being loaded from `adminjavascripts` instead of `admin/javascripts`.
