### PR TITLE
Generate .gitignore for new project.

### DIFF
--- a/lib/helios/commands/new.rb
+++ b/lib/helios/commands/new.rb
@@ -37,6 +37,7 @@ command :new do |c|
         erb = ERB.new(File.read(template))
 
         next if file === "Gemfile" and options.skip_gemfile
+        next if file === ".gitignore" and options.skip_git
 
         if File.exist?(file)
           if options.force and not options.skip

--- a/lib/helios/templates/.gitignore.erb
+++ b/lib/helios/templates/.gitignore.erb
@@ -1,0 +1,1 @@
+.sass-cache


### PR DESCRIPTION
While setting up my first helios app on Heroku, I found that the `helios server` command will create `.sass-cache` folder.

Thus I added a `.gitignore` template and also make sure that `helios new` won't generate `.gitignore` file while `--skip-git option` passed.

Thanks for your nice work. You always created something amazing. :+1:
