### PR TITLE
Added support for aps's new `content-available` key.

### DIFF
--- a/lib/helios/backend/push-notification.rb
+++ b/lib/helios/backend/push-notification.rb
@@ -73,6 +73,7 @@ class Helios::Backend::PushNotification < Sinatra::Base
     options[:alert] = options["aps"]["alert"]
     options[:badge] = options["aps"]["badge"]
     options[:sound] = options["aps"]["sound"]
+    options[:'content-available'] = options["aps"]["content-available"]
     options.delete("aps")
 
     begin

--- a/lib/helios/version.rb
+++ b/lib/helios/version.rb
@@ -1,3 +1,3 @@
 module Helios
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Kinda super duper importantly necessary for iOS 7 silent push notifications.
